### PR TITLE
Check for NULL values before believing the column type.

### DIFF
--- a/adodb.go
+++ b/adodb.go
@@ -298,6 +298,10 @@ func (rc *AdodbRows) Next(dest []driver.Value) error {
 		}
 		sc, err := oleutil.GetProperty(field, "NumericScale")
 		field.Release()
+		if val.VT == 1 /* VT_NULL */ {
+			dest[i] = nil
+			continue
+		}
 		switch typ.Val {
 		case 0: // ADEMPTY
 			dest[i] = nil


### PR DESCRIPTION
No matter what type the column says it is, the value could be a NULL,
so we need to check the variant type first. Otherwise we read nonsense
data.
